### PR TITLE
DO NOT MERGE! Adding CompiledMetadata type

### DIFF
--- a/common-api/compiler/type/output.ts
+++ b/common-api/compiler/type/output.ts
@@ -24,6 +24,12 @@ export interface CompilationResult {
       [contract: string]: CompiledContract
     }
   }
+  metadata: {
+    /** Return metadata if exists */
+    [fileName: string]: {
+      [metadata: string]: CompiledMetadata
+    }
+  }
 }
 
 ///////////
@@ -161,6 +167,14 @@ export interface CompiledContract {
     /** Binary format (hex string) */
     wasm: string
   }
+}
+
+///////////////
+// METADATA //
+//////////////
+export interface CompiledMetadata {
+  // Compiled metadata
+  solidityMetadata: string
 }
 
 /////////


### PR DESCRIPTION
Adding CompiledMetadata type to output, @yann300 probably something is still missing for this to work.

In another PR metadata is persisted to Remix artifacts, now idea was to have metadata as part of the CompilationResult interface.

Maybe there is some better way. @GrandSchtroumpf 