### PR TITLE
Upgrade Sourcify plugin to 0.7.0-beta

### DIFF
--- a/plugins/source-verifier/profile.json
+++ b/plugins/source-verifier/profile.json
@@ -2,7 +2,7 @@
 	"name": "source-verification",
 	"displayName": "Sourcify",
 	"description": "Source metadata fetcher and validator",
-	"version": "0.6.0-beta",
+	"version": "0.7.0-beta",
 	"methods": [
 		"fetch",
 		"fetchAndSave",
@@ -13,7 +13,7 @@
 	"kind":"none",
 	"icon": "https://raw.githubusercontent.com/Shard-Labs/remix-contract-getter/master/public/sourcify.png",
 	"location": "sidePanel",
-	"url": "https://sourcify.web.app/",
+	"url": "ipfs://QmYSGEyk7FVrRq9xkraqJXcGFjfANMdGUdtjxMwQKkjNVh",
 	"documentation": "https://github.com/ethereum/sourcify",
 	"targets":["remix","vscode"]
 }


### PR DESCRIPTION
Sourcify plugin upgrade:
- Fixed verification functionality
- Correct display of files to be sent to Sourcify server
- Removed `browser` prepending as requested
- Add xDAI chain support
- Validate address before fetching/verifying
- Trim address and convert to checksummed format
- Minor bug fixes and improvements

I guess someone from the Remix team will handle pointing https://sourcify.web.app/ to the provided IPFS address?

The implementation changes can be found [here](https://github.com/sourcifyeth/remix-sourcify/commit/a399cbdef1b9f16c717db132a7af521aea0aa814).