### PR TITLE
Update the chain list in the Sourcify plugin

### DIFF
--- a/plugins/source-verifier/profile.json
+++ b/plugins/source-verifier/profile.json
@@ -13,7 +13,7 @@
 	"kind":"none",
 	"icon": "https://raw.githubusercontent.com/Shard-Labs/remix-contract-getter/master/public/sourcify.png",
 	"location": "sidePanel",
-	"url": "ipfs://QmdLgwngiHwK67722kuaK1FYksVM16rXJinBJnAPkeLQUS",
+	"url": "ipfs://QmNhVyMxaWMVM6RTDwWnEUJ7kiasVetdvm2kCg8FAh9zzQ",
 	"documentation": "https://github.com/ethereum/sourcify",
 	"targets":["remix","vscode"]
 }


### PR DESCRIPTION
This PR synchronizes the list of available chains in the Sourcify plugin with the list on https://sourcify.dev, i.e. adds those chains that were missing.

Changes: https://github.com/sourcifyeth/remix-sourcify/commit/3ec23b91c7e0c56e4bf0ddbcdf24423bb377438f