### PR TITLE
Add targets to ZoKrates plugin

### DIFF
--- a/plugins/zokrates/profile.json
+++ b/plugins/zokrates/profile.json
@@ -5,8 +5,9 @@
     "documentation": "https://zokrates.github.io/",
     "methods": [],
     "events": [],
-    "version": "0.1.0-beta",
+    "version": "0.2.0-beta",
     "url": "https://zokrates.github.io/zokrates-remix-plugin/",
     "icon": "https://zokrates.github.io/zokrates-remix-plugin/zokrates.svg",
-    "location": "sidePanel"
+    "location": "sidePanel",
+    "targets": ["remix", "vscode"]
   }


### PR DESCRIPTION
Added `targets` field so the plugin can be run in the remix vs code extension (https://github.com/Zokrates/zokrates-remix-plugin/issues/46)