### PR TITLE
Add Nahmii plugin metadata.

### DIFF
--- a/plugins/nahmii/profile.json
+++ b/plugins/nahmii/profile.json
@@ -1,0 +1,12 @@
+{
+    "name": "nahmii-compiler",
+    "displayName": "Nahmii Compiler",
+    "description": "Compiler for Nahmii 2.0.",
+    "version": "0.1.0",
+    "events": [],
+    "methods": [],
+    "kind": "none",
+    "icon": "https://cdn-images-1.medium.com/max/140/1*d5P-r_Ax5zx-Q70plxwIfQ@2x.png",
+    "location": "sidePanel",
+    "url": "https://remix-nahmii-compiler-plugin.surge.sh"
+}


### PR DESCRIPTION
This pull request adds the [Nahmii](https://www.nahmii.io/) compiler plugin for Remix to the plugins directory.

Nahmii is an EVM compatible L2 solution that requires its own compiler opcodes. To simplify the life of developers who want to rapidly prototype on our platform, we'd like to offer them support for development from within Remix.