### PR TITLE
Add metadata for Contract Import for Etherscan plugin 

### DIFF
--- a/plugins/etherscan-import/profile.json
+++ b/plugins/etherscan-import/profile.json
@@ -1,0 +1,13 @@
+{
+  "name": "etherscan-import",
+  "displayName": "Import for Etherscan",
+  "description": "Import Contracts from Etherscan websites.",
+  "version": "0.1.0",
+  "events": [],
+  "methods": [],
+  "kind": "none",
+  "icon": "https://radiantgradient.org/remix/plugins/etherscan-import/img/icon.svg",
+  "location": "sidePanel",
+  "documentation": "https://github.com/world177/Etherscan-Import-for-Remix",
+  "url": "https://radiantgradient.org/remix/plugins/etherscan-import/"
+}


### PR DESCRIPTION
This adds the metadata for the plugin that I created in [this repository](https://github.com/world177/Etherscan-Import-for-Remix). It makes it more obvious and easier to import contracts found on Etherscan websites into Remix. 