### PR TITLE
Rename Cookbook Plugin

### DIFF
--- a/build/metadata.json
+++ b/build/metadata.json
@@ -29,21 +29,22 @@
 		"location": "sidePanel"
 	},
 	{
-		"name": "cookbook.dev",
+		"name": "cookbookdev",
 		"displayName": "Cookbook.dev",
-		"description": "Find any smart contract.",
-		"version": "0.1.0",
+		"description": "Find any smart contract, protocol, and library.",
+		"version": "0.1.2",
 		"events": [],
 		"methods": [
-			"openContract"
+			"openContract",
+			"openProtocol"
 		],
 		"kind": "none",
 		"icon": "https://www.cookbook.dev/img/logo.svg",
 		"location": "sidePanel",
 		"documentation": "https://www.cookbook.dev",
 		"url": "https://www.cookbook.dev/remix-plugin",
-		"maintainedBy": "JamJomJim",
-		"authorContact": "james@cookbook.dev",
+		"maintainedBy": "TylerSehr",
+		"authorContact": "tyler@cookbook.dev",
 		"targets": [
 			"remix",
 			"vscode"

--- a/build/metadata.json
+++ b/build/metadata.json
@@ -29,6 +29,28 @@
 		"location": "sidePanel"
 	},
 	{
+		"name": "cookbook.dev",
+		"displayName": "Cookbook.dev",
+		"description": "Find any smart contract, protocol, and library.",
+		"version": "0.1.2",
+		"events": [],
+		"methods": [
+			"openContract",
+			"openProtocol"
+		],
+		"kind": "none",
+		"icon": "https://www.cookbook.dev/img/logo.svg",
+		"location": "sidePanel",
+		"documentation": "https://www.cookbook.dev",
+		"url": "https://www.cookbook.dev/remix-plugin",
+		"maintainedBy": "TylerSehr",
+		"authorContact": "tyler@cookbook.dev",
+		"targets": [
+			"remix",
+			"vscode"
+		]
+	},
+	{
 		"name": "cookbookdev",
 		"displayName": "Cookbook.dev",
 		"description": "Find any smart contract, protocol, and library.",

--- a/plugins/cookbook.dev/profile.json
+++ b/plugins/cookbook.dev/profile.json
@@ -1,0 +1,16 @@
+{
+  "name": "cookbook.dev",
+  "displayName": "Cookbook.dev",
+  "description": "Find any smart contract, protocol, and library.",
+  "version": "0.1.2",
+  "events": [],
+  "methods": ["openContract", "openProtocol"],
+  "kind": "none",
+  "icon": "https://www.cookbook.dev/img/logo.svg",
+  "location": "sidePanel",
+  "documentation": "https://www.cookbook.dev",
+  "url": "https://www.cookbook.dev/remix-plugin",
+  "maintainedBy": "TylerSehr",
+  "authorContact": "tyler@cookbook.dev",
+  "targets": ["remix", "vscode"]
+}

--- a/plugins/cookbookdev/profile.json
+++ b/plugins/cookbookdev/profile.json
@@ -1,16 +1,16 @@
 {
-  "name": "cookbook.dev",
+  "name": "cookbookdev",
   "displayName": "Cookbook.dev",
-  "description": "Find any smart contract.",
-  "version": "0.1.0",
+  "description": "Find any smart contract, protocol, and library.",
+  "version": "0.1.2",
   "events": [],
-  "methods": ["openContract"],
+  "methods": ["openContract", "openProtocol"],
   "kind": "none",
   "icon": "https://www.cookbook.dev/img/logo.svg",
   "location": "sidePanel",
   "documentation": "https://www.cookbook.dev",
   "url": "https://www.cookbook.dev/remix-plugin",
-  "maintainedBy": "JamJomJim",
-  "authorContact": "james@cookbook.dev",
+  "maintainedBy": "TylerSehr",
+  "authorContact": "tyler@cookbook.dev",
   "targets": ["remix", "vscode"]
 }


### PR DESCRIPTION
Rename the Cookbook plugin without uninstalling the plugin for active users. All inbound links to uninstall old plugin and install new plugin.