### PR TITLE
Clean up the Starknet plugin's name

### DIFF
--- a/plugins/starknet/profile.json
+++ b/plugins/starknet/profile.json
@@ -1,5 +1,5 @@
 {
-    "name": "Starknet-cairo1-compiler",
+    "name": "Starknet",
     "displayName": "Starknet",
     "methods": [],
     "version": "0.1.0-alpha",


### PR DESCRIPTION
The Starknet plugin is getting some use, and the https://remix.ethereum.org/?#activate=Starknet-cairo1-compiler link is beginning to be used by some tutorials. We would like to change this to Starknet since the compiler has already moved from Cairo 1 to Cairo 2. We will coordinate with the users to make sure they've updated the links.
