### PR TITLE
update moonbeam remix plugin

### DIFF
--- a/plugins/moonbeam/profile.json
+++ b/plugins/moonbeam/profile.json
@@ -4,12 +4,12 @@
   "description": "Deploy and interact with Moonbeam.",
   "events": [],
   "methods": [],
-  "url": "https://purestake.github.io/moonbeam-remix-plugin",
-  "repo": "https://github.com/PureStake/moonbeam-remix-plugin",
-  "maintainedBy": "Purestake",
-  "authorContact": "",
-  "icon": "https://purestake.github.io/moonbeam-remix-plugin/icon.png",
-  "documentation": "https://github.com/purestake/moonbeam-remix-plugin",
+  "url": "https://moonbeam-foundation.github.io/moonbeam-remix-plugin",
+  "repo": "https://github.com/moonbeam-foundation/moonbeam-remix-plugin",
+  "maintainedBy": "Moonbeam Foundation",
+  "authorContact": "alberto@papermoon.io",
+  "icon": "https://moonbeam-foundation.github.io/moonbeam-remix-plugin/icon.png",
+  "documentation": "https://github.com/moonbeam-foundation/moonbeam-remix-plugin",
   "version": "0.0.1",
   "location": "sidePanel"
 }


### PR DESCRIPTION
Fixes the 404 that occurs on the Moonbeam Remix plugin. This is because github repositories changed ownership to the Moonbeam Foundation. This PR sorts this out and has been successfully tested via "Connect to a Local Plugin"