### PR TITLE
add dapp-draft profile

### DIFF
--- a/plugins/dapp-draft/profile.json
+++ b/plugins/dapp-draft/profile.json
@@ -1,0 +1,19 @@
+{
+  "name": "dapp-draft",
+  "displayName": "Dapp Draft",
+  "description": "Edit and deploy your own dapp!",
+  "version": "0.1.0",
+  "methods": [
+    "edit"
+  ],
+  "kind": "none",
+  "icon": "https://remix-dapp-draft-plugin.pages.dev/dappDraft.webp",
+  "location": "mainPanel",
+  "url": "https://remix-dapp-draft-plugin.pages.dev/",
+  "repo": "https://github.com/drafish/remix-dapp-draft-plugin",
+  "maintainedBy": "Remix CC",
+  "authorContact": "",
+  "targets": [
+    "remix"
+  ]
+}


### PR DESCRIPTION
I think I should keep dapp-draft external for now, so that your team wouldn't need to review the code, and I can publish this plugin as soon as possible. @ryestew @yann300 