### PR TITLE
Add COTI plugin

### DIFF
--- a/plugins/coti/profile.json
+++ b/plugins/coti/profile.json
@@ -7,7 +7,7 @@
     "url": "https://remix.coti.io",
     "icon": "https://remix.coti.io/coti-plugin-logo.png",
     "documentation": "https://docs.coti.io/coti-v2-documentation/developer-tooling/coti-remix-plugin",
-    "version": "1.0.0",
+    "version": "0.1.1-beta",
     "location": "sidePanel",
     "maintainedBy": "COTI team",
     "authorContact": "product@coti.io"

--- a/plugins/coti/profile.json
+++ b/plugins/coti/profile.json
@@ -1,0 +1,15 @@
+{
+    "name": "coti-remix-plugin",
+    "displayName": "COTI",
+    "description": "Deploy and interact with contracts on the COTI privacy-preserving network",
+    "events": [],
+    "methods": [],
+    "url": "https://remix.coti.io",
+    "icon": "https://remix.coti.io/coti-plugin-logo.png",
+    "documentation": "https://docs.coti.io/coti-v2-documentation/developer-tooling/coti-remix-plugin",
+    "version": "1.0.0",
+    "location": "sidePanel",
+    "maintainedBy": "COTI team",
+    "authorContact": "product@coti.io"
+  }
+  


### PR DESCRIPTION
The COTI plugin provides functionality for developers to onboard accounts onto the COTI network as well as build, deploy, and interact with smart contracts on the COTI privacy-preserving network.

Docs https://docs.coti.io/coti-v2-documentation/developer-tooling/coti-remix-plugin