### PR TITLE
Rename defender plugin

### DIFF
--- a/plugins/defender-deploy/profile.json
+++ b/plugins/defender-deploy/profile.json
@@ -6,7 +6,7 @@
   "methods": [],
   "url": "https://defeder-remix-deploy.netlify.app/",
   "icon": "https://defeder-remix-deploy.netlify.app/logo.png",
-  "repo": "https://github.com/OpenZeppelin/defender-remix-plugin",
+  "repo": "https://github.com/OpenZeppelin/defender-deploy-plugin",
   "documentation": "https://docs.openzeppelin.com/defender/remix-plugin",
   "maintainedBy": "OpenZeppelin Defender team",
   "authorContact": "",


### PR DESCRIPTION
## Description

We just renamed the repo name from `defender-remix-plugin` to `defender-deploy-plugin`