### PR TITLE
Add Aztec plugin

### DIFF
--- a/plugins/aztec/profile.json
+++ b/plugins/aztec/profile.json
@@ -1,0 +1,15 @@
+{
+    "name": "aztec-network",
+    "displayName": "Aztec",
+    "description": "Compile, deploy, and interact with smart contracts written in Noir for the Aztec network.",
+    "version": "0.1.0-alpha",
+    "url": "https://hsy822.github.io",
+    "location": "sidePanel",
+    "icon": "https://hsy822.github.io/icon.png",
+    "documentation": "https://github.com/hsy822/aztec-remix-plugin#readme",
+    "repo": "https://github.com/hsy822/aztec-remix-plugin",
+    "maintainedBy": "Sooyoung",
+    "authorContact": "bitcommune@gmail.com",
+    "methods": [],
+    "events": []
+  }


### PR DESCRIPTION
This PR adds a new plugin for Aztec, a privacy-focused L2 network for Ethereum.

The plugin allows developers to:
- Compile Noir-based smart contracts using aztec-nargo
- Deploy to the Aztec Network
- Interact with deployed contracts via simulate/send
- Import example projects

Repo: https://github.com/hsy822/aztec-remix-plugin
